### PR TITLE
feat(a11y): add accessibility helpers

### DIFF
--- a/src/utils/accessibility.ts
+++ b/src/utils/accessibility.ts
@@ -1,0 +1,36 @@
+// Accessibility utility functions
+
+export function getAriaLabel(element: string, action?: string): string {
+  return action ? `${action} ${element}` : element;
+}
+
+export function trapFocus(container: HTMLElement): () => void {
+  const focusableEls = container.querySelectorAll(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+  const firstEl = focusableEls[0] as HTMLElement;
+  const lastEl = focusableEls[focusableEls.length - 1] as HTMLElement;
+
+  const handler = (e: KeyboardEvent) => {
+    if (e.key !== 'Tab') return;
+    if (e.shiftKey) {
+      if (document.activeElement === firstEl) { lastEl.focus(); e.preventDefault(); }
+    } else {
+      if (document.activeElement === lastEl) { firstEl.focus(); e.preventDefault(); }
+    }
+  };
+
+  container.addEventListener('keydown', handler);
+  firstEl?.focus();
+  return () => container.removeEventListener('keydown', handler);
+}
+
+export function announceToScreenReader(message: string): void {
+  const el = document.createElement('div');
+  el.setAttribute('role', 'status');
+  el.setAttribute('aria-live', 'polite');
+  el.className = 'sr-only';
+  el.textContent = message;
+  document.body.appendChild(el);
+  setTimeout(() => el.remove(), 1000);
+}


### PR DESCRIPTION
Accessibility improvements with focus trap and screen reader support.
Co-authored-by: DHV Team <dhvteam@users.noreply.github.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds small accessibility helpers to improve keyboard navigation and screen reader support. Focus stays inside modals, and important updates are announced to assistive tech.

- **New Features**
  - trapFocus(container): traps Tab focus within a container; returns a cleanup to remove the handler.
  - announceToScreenReader(message): creates a polite aria-live status to announce messages for 1s.
  - getAriaLabel(element, action?): builds simple, consistent ARIA labels (e.g., "Close dialog").

<sup>Written for commit 01d8e5e17dc047cbb2c2d44135e5b4a73362cc4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced screen reader support with improved announcements for dynamic content changes and user interactions.
  * Added keyboard focus management features to ensure proper navigation and focus trapping within interactive components and dialogs.
  * Improved semantic accessibility labeling for better support across assistive technologies and screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->