### PR TITLE
feat(utils): add string utilities

### DIFF
--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,0 +1,34 @@
+// String utility functions
+
+export function removeVietnameseTones(str: string): string {
+  return str.normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\u0111/g, 'd')
+    .replace(/\u0110/g, 'D');
+}
+
+export function maskEmail(email: string): string {
+  const parts = email.split('@');
+  if (parts.length !== 2) return email;
+  const name = parts[0];
+  const masked = name.charAt(0) + '***' + name.charAt(name.length - 1);
+  return masked + '@' + parts[1];
+}
+
+export function maskPhone(phone: string): string {
+  if (phone.length < 4) return phone;
+  return phone.slice(0, -4).replace(/./g, '*') + phone.slice(-4);
+}
+
+export function pluralize(count: number, singular: string, plural?: string): string {
+  return count === 1
+    ? count + ' ' + singular
+    : count + ' ' + (plural || singular + 's');
+}
+
+export function highlightSearchTerm(text: string, term: string): string {
+  if (!term.trim()) return text;
+  const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp('(' + escaped + ')', 'gi');
+  return text.replace(regex, '<mark>$1</mark>');
+}


### PR DESCRIPTION
String helpers for Vietnamese text processing.
Co-authored-by: DHV Team <dhvteam@users.noreply.github.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a set of small string utilities to help with Vietnamese text handling, masking sensitive data, and simple display formatting. These helpers improve consistency across the app.

- **New Features**
  - removeVietnameseTones: strips diacritics and normalizes Đ/đ.
  - maskEmail: keeps first/last character, masks the middle.
  - maskPhone: masks all but the last 4 digits.
  - pluralize: returns “count singular/plural”.
  - highlightSearchTerm: wraps matches in <mark>, case-insensitive and regex-safe.

<sup>Written for commit 7630f03730cadc1fc47012a32caa3ba3e47a4e6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

